### PR TITLE
missed the use of rAF polyfill

### DIFF
--- a/lib/simulation.js
+++ b/lib/simulation.js
@@ -1,5 +1,6 @@
 var Vector = require('./vector')
   , bodies = []
+  , raf = require('raf')
 
 function increment(a, b, c, d) {
   var vec = Vector(0, 0)
@@ -46,7 +47,7 @@ var currentTime = Date.now() / 1000
   , dt = 0.015
 
 function simulate() {
-  requestAnimationFrame(function() {
+  raf(function() {
     simulate()
     var newTime = Date.now() / 1000
     var frameTime = newTime - currentTime


### PR DESCRIPTION
This should fix #4 .
Tested with "Chat Heads" and "pulldownMenu" demos under Safari iOS 6.1 (Simulator)
