### PR TITLE
postpone the creaion of the prefix transformProp until it is needed.

### DIFF
--- a/impulse.js
+++ b/impulse.js
@@ -741,7 +741,7 @@ Interact.prototype.end = function() {
 },{"./boundary":5,"./util":13,"./vector":14,"lodash.defaults":16,"promise":23,"touch-velocity":27}],10:[function(require,module,exports){
 var prefixes = ['Webkit', 'Moz', 'Ms', 'ms']
 var calls = []
-var transformProp = prefixed('transform')
+var transformProp
 var raf = require('raf')
 
 function loop() {
@@ -782,6 +782,9 @@ function Renderer(els) {
 
 Renderer.prototype.render = function() {
   if(!this.currentPosition) return
+
+  if(!transformProp)
+    transformProp = prefixed('transform');
   var transformsToApply
     , els = this.els
     , position = this.currentPosition
@@ -1781,13 +1784,13 @@ Promise.all = function () {
 }
 
 Promise.reject = function (value) {
-  return new Promise(function (resolve, reject) { 
+  return new Promise(function (resolve, reject) {
     reject(value);
   });
 }
 
 Promise.race = function (values) {
-  return new Promise(function (resolve, reject) { 
+  return new Promise(function (resolve, reject) {
     values.forEach(function(value){
       Promise.resolve(value).then(resolve, reject);
     })

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,6 +1,6 @@
 var prefixes = ['Webkit', 'Moz', 'Ms', 'ms']
 var calls = []
-var transformProp = prefixed('transform')
+var transformProp
 var raf = require('raf')
 
 function loop() {
@@ -41,6 +41,9 @@ function Renderer(els) {
 
 Renderer.prototype.render = function() {
   if(!this.currentPosition) return
+
+  if(!transformProp)
+    transformProp = prefixed('transform');
   var transformsToApply
     , els = this.els
     , position = this.currentPosition


### PR DESCRIPTION
This is needed when loading impulse in head (before the document.body is defined). Finding the proper browser prefix for the transform style, can only be done when the document.body.style was initiated.
I'm trying to integrate impulse as a meteor package (meteor.com). Meteor builds all client-side js in a single file and loads it in head.
