### PR TITLE
Removed preventDefault

### DIFF
--- a/lib/drag.js
+++ b/lib/drag.js
@@ -62,7 +62,6 @@ Drag.prototype._setupHandle = function(el) {
 
 Drag.prototype._start = function(evt) {
   this._startTime = Date.now()
-  evt.preventDefault()
   this._mousedown = true
   this._interaction = this._phys.interact({
     boundary: this._opts.boundary,
@@ -84,7 +83,6 @@ Drag.prototype._move = function(evt) {
 
 Drag.prototype._end = function(evt) {
   if(!this._mousedown) return
-  evt.preventDefault()
 
   this._mousedown = false
 


### PR DESCRIPTION
Are those preventDefault calls important?

In my case, where I had list of links with vertical scroll they prevented user from navigating the link. Can these 2 lines be safely removed?
